### PR TITLE
Fix Track step/audio layering issue 

### DIFF
--- a/src/components/Track.tsx
+++ b/src/components/Track.tsx
@@ -133,12 +133,14 @@ const TrackConsumer: React.FC<TrackConsumerProps> = ({
           );
 
           if (!isEqual) {
+            sequencer.current.stop();
             sequencer.current?.remove(i);
             sequencer.current?.add(i, step);
           }
         });
       } else {
         // When new steps are less or more then prev, remove all and add new steps
+        sequencer.current.stop();
         sequencer.current.removeAll();
         sequencerSteps.forEach((step, i) => {
           sequencer.current.add(i, step);


### PR DESCRIPTION
Resolves #42

Stop sequencer before removing/adding new steps to prevent duplicate notes from being played when they change

I published a forked version of the package w/ the changes I described in that issue and updated a fork of the sandbox to use it, and it sounds like the issue is resolved: https://codesandbox.io/s/reactronica-42-step-duplication-bug-fixed-w-fork-of-package-fhtly?file=/src/App.tsx